### PR TITLE
Streamline startup for Dart Dev Tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chrome-devtools-frontend",
   "description": "Chrome DevTools UI",
   "scripts": {
-    "start": "node scripts/start_chrome_and_server.js",
+    "start": "node scripts/dart_debug.js",
     "chrome": "node scripts/chrome_debug_launcher/launch_chrome.js",
     "server": "node scripts/hosted_mode/server.js",
     "test": "node scripts/npm_test.js",
@@ -32,6 +32,9 @@
     "url": "https://bugs.chromium.org/p/chromium/issues/list?can=2&q=component:Platform%3EDevTools%20&sort=-opened&colspec=ID%20Stars%20Owner%20Summary%20Modified%20Opened"
   },
   "homepage": "https://devtools.chrome.com",
+  "dependencies": {
+    "chrome-remote-interface": "^0.25.6"
+  },
   "devDependencies": {
     "ajv": "^5.1.5"
   }

--- a/scripts/chrome_debug_launcher/launch_chrome.js
+++ b/scripts/chrome_debug_launcher/launch_chrome.js
@@ -27,8 +27,7 @@ if (utils.includes(process.argv, Flags.RESET_PROFILE)) {
 var chromeArgs = [
   `--remote-debugging-port=${REMOTE_DEBUGGING_PORT}`,
   `--custom-devtools-frontend=http://localhost:${SERVER_PORT}/front_end/`, `--no-first-run`,
-  '--enable-devtools-experiments', `http://localhost:${REMOTE_DEBUGGING_PORT}#custom=true&experiments=true`,
-  `https://devtools.chrome.com`, `--user-data-dir=${CHROME_PROFILE_PATH}`
+  '--enable-devtools-experiments', `--user-data-dir=${CHROME_PROFILE_PATH}`
 ].concat(process.argv.slice(2));
 
 if (process.platform === 'win32') {

--- a/scripts/dart_debug.js
+++ b/scripts/dart_debug.js
@@ -1,0 +1,23 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+var childProcess = require('child_process');
+var path = require('path');
+var cdp = require('chrome-remote-interface');
+
+var server = childProcess.fork(path.join(__dirname, 'hosted_mode/server.js'));
+var chrome = childProcess.fork(path.join(__dirname, 'chrome_debug_launcher/launch_chrome.js'), ['go/ddc', 'api.dartlang.org/dev']);
+
+chrome.on('exit', function() {
+  server.kill();
+});
+
+// TODO(vsm): Wait properly for Chrome to start.  For now, waiting 1s.
+setTimeout(() => {
+  var app = cdp.New({url: process.argv[2]});
+  app.then((o) => {
+    var devPage = o.devtoolsFrontendUrl.split('?')[1];
+    var dev = cdp.New({url: "chrome-devtools://devtools/custom/inspector.html?" + devPage + "&experiments=true"});
+  });
+}, 1000);


### PR DESCRIPTION
The following:
> npm start <url>

will now open Chrome with a debugging session on the given url.