### PR TITLE
Bump the hard-coded delay waiting for Chrome to start

### DIFF
--- a/scripts/dart_debug.js
+++ b/scripts/dart_debug.js
@@ -13,11 +13,11 @@ chrome.on('exit', function() {
   server.kill();
 });
 
-// TODO(vsm): Wait properly for Chrome to start.  For now, waiting 1s.
+// TODO(vsm): Wait properly for Chrome to start.  For now, waiting 3s.
 setTimeout(() => {
   var app = cdp.New({url: process.argv[2]});
   app.then((o) => {
     var devPage = o.devtoolsFrontendUrl.split('?')[1];
     var dev = cdp.New({url: "chrome-devtools://devtools/custom/inspector.html?" + devPage + "&experiments=true"});
   });
-}, 1000);
+}, 3000);


### PR DESCRIPTION
I can't see an obvious way to wait on the forked process, which in turn runs Chrome. For me this only fails the first time. Increase the delay to 3s as a workaround.