### PR TITLE
Temporarily disable the dark theme default

### DIFF
--- a/front_end/main/module.json
+++ b/front_end/main/module.json
@@ -204,7 +204,7 @@
             "title": "Theme:",
             "settingName": "uiTheme",
             "settingType": "enum",
-            "defaultValue": "dark",
+            "defaultValue": "default",
             "options": [
                 {
                     "title": "Switch to light theme",


### PR DESCRIPTION
Until the DDC changes are in a published version the custom formats are too hard to read.

TBR