### PR TITLE
Refresh breakpoints on hot restart

### DIFF
--- a/front_end/sdk/DebuggerModel.js
+++ b/front_end/sdk/DebuggerModel.js
@@ -84,7 +84,12 @@ SDK.DebuggerModel = class extends SDK.SDKModel {
   static _sourceMapId(executionContextId, sourceURL, sourceMapURL) {
     if (!sourceMapURL)
       return null;
-    return executionContextId + ':' + sourceURL + ':' + sourceMapURL;
+    // TODO(vsm): For Dart, the sourceURL has a cache-busting tag.
+    // Not clear we need both the sourceURL and the sourceMapURL,
+    // so suppressing the former.  Alternatively, we could strip
+    // the cache-busting tag.  Either keeps the sourceMapId consistent
+    // across hot reloads.
+    return executionContextId + /* ':' + sourceURL + */ ':' + sourceMapURL;
   }
 
   /**


### PR DESCRIPTION
Our internal JS files have a cache busting URI for JS files but not source maps.  This appears to confuse the source map refresh logic when a new JS file is loaded while running.  With this change, the old source map is reset properly.

@alan-knight 