### PR TITLE
Add basic infrastructure for running Dart tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,9 @@
+targets:
+  $default:
+    sources:
+      - front_end/dart_tests/**
+      - front_end/sdk/**
+      - scripts/**
+      - services/**
+      - test/**
+      - lib/**

--- a/front_end/dart_tests/dart_support_test.dart
+++ b/front_end/dart_tests/dart_support_test.dart
@@ -1,0 +1,46 @@
+/// Test the dart support functions standalone.
+
+// TODO(alanknight): How do we test things that only run in the context of
+// devtools?
+
+@JS()
+library dart_support_test;
+
+@TestOn('chrome')
+import 'package:test/test.dart';
+import 'package:js/js.dart';
+import 'dart:html';
+import 'dart:async';
+import 'dart:developer';
+
+@JS()
+external String $dartExpressionFor(context, String expression);
+
+@JS('eval')
+external jsEval(String expression);
+
+unmodified(String s) {
+  var result = $dartExpressionFor(null, s);
+  expect(result.split('\n').last.trim(), s);
+}
+
+main() async {
+
+  setUp(() async {
+    var element = new ScriptElement()
+      ..type = 'text/javascript'
+      ..src = 'packages/dart_devtools/sdk/DartSupport.js';
+    document.body.append(element);
+    await new Future.delayed(new Duration(seconds: 2));
+    await element.onLoad.take(1);
+  });
+
+  test("Doesn't look like Dart", () {
+    unmodified('a/&*');
+  });
+
+  // It would be useful to test evaluation of Dart expressions
+  // and them correctly finding variables in scope, but I'm
+  // fairly convinced that this isn't going to be possible without spawning an
+  // isolate or something similar.
+}

--- a/front_end/sdk/DartSupport.js
+++ b/front_end/sdk/DartSupport.js
@@ -90,7 +90,7 @@ window.$dartExpressionFor = function(executionContext, dartExpression) {
     if (!component.match(looksLikeIdentifier)) {
       return `console.log("%c(Cannot evaluate as a Dart expression, using JS eval)",
           "background-color: hsl(50, 100%, 95%)");
-      ${dartExpression};`;
+      ${dartExpression}`;
     }
   }
   var receiver = components[0];

--- a/lib/sdk
+++ b/lib/sdk
@@ -1,0 +1,1 @@
+../front_end/sdk

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,16 @@
+name: dart_devtools
+description: DDC debugging tool based on Chrome DevTools
+version: 0.0.1
+homepage: https://github.com/dart-lang/devtools-frontend
+author: Dart Team <misc@dartlang.org>
+
+environment:
+  sdk: '>=2.0.0-dev.55.0 <2.1.0'
+
+dev_dependencies:
+  path: ^1.6.0
+  build_runner: ^0.10.0
+  build_web_compilers: ^0.4.0
+  build_test: ^0.10.0
+  test: ^1.3.0
+  js: ^0.6.0

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,1 @@
+pub run build_runner test -- -p chrome

--- a/test
+++ b/test
@@ -1,0 +1,1 @@
+front_end/dart_tests


### PR DESCRIPTION
Also adds enough for this to act like a Dart package. The only test so far is trivial, because it's very difficult to get an evaluation test working.