### PR TITLE
Stop on exceptions, even when the SDK is blackboxed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,6 @@
  * Download and check-in the files that are normally read from the
    chrome-devtools-frontend site, in the interests of having this entirely
    statically serveable. Those files will need to be updated for Chrome changes.
+ * When blackboxing the SDK it doesn't stop on Dart exceptions, since they're in
+   blackboxed source. Set the blackbox by source range to get around this. This
+   isn't visible in the UI, so it's hard-coded.


### PR DESCRIPTION
This uses the ability to blackbox ranges. We specifically omit dart.throw. Exceptions thrown directly from JS probably won't work with this, but this will catch the most common cases.

The way we're finding the range is horrible right now. We get the full text of the SDK, split it into lines, look for the line that's the beginning of dart.throw and use that. Hopefully +jmesserly can make the compiler just give us that information soon.