### PR TITLE
 Talk directly to the Dart build server instead of any front-end, to avoid CORS issues

### DIFF
--- a/front_end/sdk/DartEval.js
+++ b/front_end/sdk/DartEval.js
@@ -111,7 +111,10 @@ Dart._Evaluation = class {
     /// which one we talk to.
     async rpcUrl() {
         if (this._rpcUrl) return this._rpcUrl;
-        const context = UI ? UI.context.flavor(SDK.ExecutionContext) : null;
+        const context = 
+            self.UI ? self.UI.context.flavor(SDK.ExecutionContext) : null;
+        // If we're in a test, bail out.
+        if (!context) return null;
         const response = await context.evaluate(
             {
                 expression: 'dart_library.roots.values().next().value',

--- a/front_end/sdk/DartSupport.js
+++ b/front_end/sdk/DartSupport.js
@@ -91,7 +91,8 @@ window.$dartExpressionFor = async function (executionContext, dartExpression) {
   const enclosingLibraryName = await evaluation.currentLibrary();
   if (!enclosingLibraryName) return dartExpression;
 
-  const response = await Dart.fetch(await evaluation.url());
+  const url = await evaluation.url();
+  const response = await Dart.fetch(url);
   const text = await response.text();
   return text;
 }
@@ -129,4 +130,4 @@ Dart.environments = async function (callFrame) {
 }
 
 /// Allow us to mock the Http fetch operation in tests.
-Dart.fetch = x => fetch(x);
+Dart.fetch = x => fetch(x, {credentials: 'include'});


### PR DESCRIPTION
If the application is being served behind a production web server in development we may not have permission to send cross-origin requests (from chrome-devtools://devtools). We can get the actual Dart build server out of the module system and use that address, for which we can send the right headers to allow the CORS request.