### PR TITLE
ddt - more robust checking for dart library name

### DIFF
--- a/front_end/dart_tests/test_helpers.dart
+++ b/front_end/dart_tests/test_helpers.dart
@@ -77,10 +77,10 @@ String urlToPackagePath(String originalUrl) {
 
 /// A class to describe all the compilation information and allow comparing it
 /// in tests.
-/// 
+///
 /// We will provide [noteCurrent] as a callback to JS code, which will then
 /// create the static [current] value. We can then compare that to an expected
-/// value. 
+/// value.
 class CompilationContext {
   static CompilationContext current;
 
@@ -176,6 +176,7 @@ class UILocation {
   // url would really be on UISourceCode.
   var _url;
   url() => _url;
+  extension() => 'dart';
 }
 
 /// A fake for the devtools SDK.DebuggerModel.CallFrame.
@@ -201,8 +202,8 @@ class FakeCallFrame {
   }
 
   /// A hard-coded scope chain for a sample file in the web directory.
-  final scopeChainWeb = [
-        Bindings('self', {'a': 1, 'b': 2, 'c': 3}),
+  get scopeChainWeb => [
+        Bindings(functionName, {'a': 1, 'b': 2, 'c': 3}),
         Bindings('library',
             {'foo__bar__web__main': _libraryBindingsWeb, 'gets_ignored': 4}),
         Bindings('global_ignored', {})
@@ -213,8 +214,8 @@ class FakeCallFrame {
       Bindings('foo__bar__web__main', {'_private': 'lib_prop'});
 
   /// A hard-coded scope chain for a sample file in the lib directory.
-  final scopeChainLib = [
-        Bindings('self', {'x': 99}),
+  get scopeChainLib => [
+        Bindings(functionName, {'x': 99}),
         Bindings('library',
             {'foo__bar__library': _libraryBindingsLib, 'gets_ignored': 4}),
         Bindings('global_ignored', {})

--- a/front_end/sdk/DartEval.js
+++ b/front_end/sdk/DartEval.js
@@ -149,9 +149,10 @@ Dart._Evaluation = class {
             'module',
             'targetName',
             'currentFile'];
-        const _encode = (name, value) => name + '=' + encodeURIComponent(value);
-        const parameters = singleParameters.map(
-            (value, i) => _encode(parameterNames[i], value));
+        const _encode = (name, value) => value && name + '=' + encodeURIComponent(value);
+        const parameters = singleParameters
+            .map((value, i) => _encode(parameterNames[i], value))
+            .filter(value => value); // Remove the null values.
         const variables = scopeVariables.map(
             (property) => _encode('property', property));
         return '?' + parameters.concat(variables).join('&');

--- a/front_end/sdk/DartEval.js
+++ b/front_end/sdk/DartEval.js
@@ -170,9 +170,13 @@ Dart._Evaluation = class {
         }
         // If DDC hasn't given a name to the function, then v8 will provide one,
         // which will be of the form
-        //     dart_library.library.thing_we_want.actualName
-        const functionName = this.callFrame.functionName;
-        if (functionName.startsWith('dart_library.library')) {
+        // dart_library.library.thing_we_want.actualName But it might not be the
+        // frame we're on, it might be an enclosing function. This is
+        // particularly common with closures like "test('name', () { ..."  So
+        // get the whole list and look for one that identifies a Dart library.
+        const functionNames = this.callFrame.scopeChain().map(scope => scope.name());
+        for (const functionName of functionNames) {
+          if (functionName && functionName.startsWith('dart_library.library')) {
             const name = functionName.split('.')[2];
             // If we're in the Dart SDK, treat that as being in JS,don't have sources.
             // TODO(alanknight): Considering evaluating as Dart when in the SDK,
@@ -180,6 +184,7 @@ Dart._Evaluation = class {
             if (name == 'dart') return null;
             this._enclosingLibraryName = name;
             return name;
+          }
         }
         // Methods have names, so using the functionName doesn't work, but
         // methods have a thisObject, which follows a similar naming convention,
@@ -195,6 +200,7 @@ Dart._Evaluation = class {
         // we need this is for main, in which case we can find the library name
         // from the module Id, but it's not clear, so let's be sure.
         const moduleId = await this._currentModuleId();
+        const functionName = functionNames[0];
         const expression = 'var module = dart._loadedModules.get("' + moduleId + '"); '
             + 'Object.keys(module).find(x => module[x]["' + functionName + '"])';
         const candidates = await this.callFrame.evaluate(

--- a/front_end/sdk/DartSupport.js
+++ b/front_end/sdk/DartSupport.js
@@ -13,7 +13,7 @@ Dart._NotificationHandler = class {
     if (window["SDK"]) {
       SDK.targetManager.addModelListener(
           SDK.DebuggerModel,
-          SDK.DebuggerModel.Events.DebuggerPaused, 
+          SDK.DebuggerModel.Events.DebuggerPaused,
           this._debuggerPaused);
     }
   }
@@ -25,15 +25,9 @@ Dart._NotificationHandler = class {
     const selectedFrame = executionContext.debuggerModel.callFrames[0];
     // We're not stopped at a breakpoint, treat it as JS.
     if (!selectedFrame) return false;
-    // Find the Dart library, if any.
-    const evaluation = new Dart._Evaluation(
-      selectedFrame,
-      executionContext,
-      '',
-      false);
-    const enclosingLibraryName = await evaluation.currentLibrary();
-    // If there's an enclosing library name, then we're in a Dart context.
-    return enclosingLibraryName != null;
+    const location = Bindings.debuggerWorkspaceBinding
+            .rawLocationToUILocation(selectedFrame.functionLocation());
+    return location.uiSourceCode.extension() == 'dart';
   }
 
   static async _debuggerPaused(event) {
@@ -124,14 +118,17 @@ window.$dartExpressionFor = async function (executionContext, dartExpression) {
   const selectedFrame = executionContext.debuggerModel.selectedCallFrame();
   // We're not stopped at a breakpoint, treat it as JS.
   if (!selectedFrame) return dartExpression;
+
+  const location = Bindings.debuggerWorkspaceBinding
+      .rawLocationToUILocation(selectedFrame.functionLocation());
+  if (location.uiSourceCode.extension() != 'dart') return dartExpression;
+
   const evaluation = new Dart._Evaluation(
     selectedFrame,
     executionContext,
     dartExpression,
     false);
   const enclosingLibraryName = await evaluation.currentLibrary();
-  if (!enclosingLibraryName) return dartExpression;
-
   try {
     const url = await evaluation.url();
     const response = await Dart.fetch(url);


### PR DESCRIPTION
We check the enclosing functions as well, and we allow for the possibility that we can't find one. Rather than assuming that a frame with no library is JS, we check that based on the containing file being .dart or not.